### PR TITLE
iguana_rpc.c fix and some changes in block explorer

### DIFF
--- a/iguana/iguana_rpc.c
+++ b/iguana/iguana_rpc.c
@@ -706,19 +706,19 @@ char *SuperNET_rpcparse(struct supernet_info *myinfo,char *retbuf,int32_t bufsiz
 {
     cJSON *tokens,*argjson,*json = 0; long filesize;
     char symbol[16],buf[4096],urlmethod[16],*data,url[1024],*retstr,*token = 0; int32_t i,j,n,num=0;
-    //printf("rpcparse.(%s)\n",urlstr);
+    printf("rpcparse.(%s)\n",urlstr);
     for (i=0; i<sizeof(urlmethod)-1&&urlstr[i]!=0&&urlstr[i]!=' '; i++)
         urlmethod[i] = urlstr[i];
     urlmethod[i++] = 0;
     n = i;
-    //printf("URLMETHOD.(%s)\n",urlmethod);
+    printf("URLMETHOD.(%s)\n",urlmethod);
     *postflagp = (strcmp(urlmethod,"POST") == 0);
     for (i=0; i<sizeof(url)-1&&urlstr[n+i]!=0&&urlstr[n+i]!=' '; i++)
         url[i] = urlstr[n+i];
     url[i++] = 0;
     n += i;
     j = i = 0;
-    //printf("url.(%s) method.(%s)\n",&url[i],urlmethod);
+    printf("url.(%s) method.(%s)\n",&url[i],urlmethod);
     if ( strcmp(&url[i],"/") == 0 && strcmp(urlmethod,"GET") == 0 )
     {
         *jsonflagp = 1;
@@ -739,7 +739,7 @@ char *SuperNET_rpcparse(struct supernet_info *myinfo,char *retbuf,int32_t bufsiz
         iguana_bitmap(retbuf,bufsize,&url[i]);
         return(retbuf);
     }
-    //printf("URL.(%s)\n",url);
+    printf("URL.(%s)\n",url);
     if ( strcmp(url,"/favicon.ico") == 0 )
     {
         *jsonflagp = -1;
@@ -927,17 +927,19 @@ void iguana_rpcloop(void *args)
             else
             {
                 if ( len > 0 )
-                {
+                {   //printf("got.(%s) %d remains.%d of total.%d\n",buf,recvlen,remains,len);
                     remains -= len;
                     recvlen += len;
                     buf = &buf[len];
-                    retstr = SuperNET_rpcparse(myinfo,space,size,&jsonflag,&postflag,jsonbuf,remoteaddr);
-                    break;
-                } else usleep(10000);
+                    //break;
+                } else {usleep(10000);
                 //printf("got.(%s) %d remains.%d of total.%d\n",jsonbuf,recvlen,remains,len);
                 //retstr = iguana_rpcparse(space,size,&postflag,jsonbuf);
-                break;
+                break;}
             }
+        }
+        if(recvlen>0){
+        retstr = SuperNET_rpcparse(myinfo,space,size,&jsonflag,&postflag,jsonbuf,remoteaddr);
         }
         //if ( retstr == 0 )
         //    retstr = iguana_htmlresponse(space,size,&remains,1,retstr,retstr != space);

--- a/iguana/index.html
+++ b/iguana/index.html
@@ -356,36 +356,28 @@ data-path="{tc}/{config}">
 
 
             <div id="Blockexplorer_page" class="page">
-                <div class="panel panel-default">
+                <div class="panel panel-default"> 
                     <!-- Default panel contents -->
                     <div class="panel-heading">
                         <h3>Block Explorer tab</h3>
                     </div>
                     <div class="panel-body center">
+                        <div class="pull-right">
+                                <span class="checkbox"><label><input id="cbChangeExternalBlocks" type="checkbox"/> Use External Blocks</label></span>
+                            </div>
                         <h3>Set Active coin</h3>
                         <div id="BlockExpCoin">
                             
                         </div>
-                        <div id="Blockhashbutton">
-                            
+                        <div >
+                            <table id="block_input_table"></table>
                         </div>
-                        <div id="Blockhashoutput">
-                            
+                        <div>
+                           
+                            <table  id="block_output_table" width="500px">
+                                
+                            </table>
                         </div>
-                        <div id="Blockbutton">
-                            
-                        </div>
-                        <div id="Blockoutput">
-                            
-                        </div>
-                        <div id="transactionButton">
-                            
-                        </div>
-                        
-                        <div id="transactionoutput">
-                            
-                        </div>
-                        
                         
                         <p>
                             ** Awaiting specific requirements **

--- a/iguana/js/api.js
+++ b/iguana/js/api.js
@@ -11,7 +11,7 @@ function tagGen(len)
 var SPNAPI = (function(SPNAPI, $, undefined) {
 
     SPNAPI.methods = {};
-    SPNAPI.pages = ["Settings","Instandex", "Pangea", "Peers","Debug", "Coins", "Blockexplorer"];
+    SPNAPI.pages = ["Instandex", "Pangea", "Peers","Debug", "Coins", "Blockexplorer"];
     SPNAPI.pageContent = {};
     SPNAPI.page = "Blockexplorer";
     /*
@@ -100,25 +100,65 @@ var SPNAPI = (function(SPNAPI, $, undefined) {
         });   
         }else{
             request = JSON.parse( request );
-        var url=SPNAPI.returnAJAXgetURL(request);
+        var usepost=SPNAPI.useGETRequest(request);
             if(url!==false){
                 
     /*
      * Ajax request will be sent if pexe is not loaded or 
      * if usepexe is set to false
      * (this adds the user the ability to handle how requests are sent)
-     */                 
-$.ajax({
+     */ 
+    if(!usepost){
+                var url=SPNAPI.returnAJAXPostURL(request);
+    $.ajax({
+    type: "POST",
+    url: url,
+    crossDomain: true,
+    dataType: 'json',
+    data: request,
+    success: function(response, textStatus, jqXHR) {
+        console.log('AJAX Response is ' + JSON.stringify(response));
+        callback(request, response);
+    },
+    error: function (responseData, textStatus, errorThrown) {
+        console.log('POST request failed.');
+    }
+
+});                  
+}else{
+    var url=SPNAPI.returnAJAXgetURL(request);
+   $.ajax({
   type: "GET",
-  url: url
-  }).done(function( response ) {
+  url: url,
+   success:function( response ) {
        console.log('AJAX Response is ' + response);
             //if(typeof callback === 'function'){
             callback(request, response);
             //}
-            });    
             }
+}); 
+}
+}
    }
+    };
+    
+    SPNAPI.useGETRequest=function(request){
+        if(request.method && (request.method==='apikeypair' || request.method==='setuserid')){
+            return false;
+        }else{
+            return true;
+        }
+    };
+    
+    SPNAPI.returnAJAXPostURL=function(request){
+        
+        var url=SPNAPI.domain+":"+SPNAPI.port;
+        if(request.method === undefined){
+            console.log("Invalid request.");
+            return false;
+        }
+        console.log("Post Url for request:"+url);
+        return url;
     };
     
     SPNAPI.returnAJAXgetURL=function(request){

--- a/iguana/js/blockexplorer.js
+++ b/iguana/js/blockexplorer.js
@@ -44,7 +44,8 @@ var callBlockEXPRPC=function(coin){
     SPNAPI.makeRequest(request, function(request,response){
         response=JSON.parse(response);
         if(response.result && response.result==='set bitcoin RPC coin'){
-            document.getElementById('Blockhashbutton').innerHTML='<button class="btn btn-raised btn-success btn-xs getBlockHashActionButton" data-height="0">Get blockhash</button>';
+            
+        blockExp_input_table();
         }
     });
 };
@@ -57,8 +58,20 @@ var callBlockEXPRPC=function(coin){
  * (initially height is set to zero)
  * 
  */
+
+var filterInt = function (value) {
+  if(/^(\-|\+)?([0-9]+|Infinity)$/.test(value))
+    return Number(value);
+  return "NaN";
+}
+
 var getBlockhash= function(height){
     
+    var height=($('#BlockExp_height').val());
+    /*
+    if (height === "NaN" || height ==='Infinity') {
+     height=0;
+    }*/
     var request="{\"agent\":\"ramchain\",\"method\":\"getblockhash\",\"height\":\""+height+"\"}";
     
     SPNAPI.makeRequest(request, function(request,response){
@@ -66,8 +79,8 @@ var getBlockhash= function(height){
             if(response.result){
                 BlockHash=response.result;
                 //Blockhashoutput
-                document.getElementById('Blockhashoutput').innerHTML='Blockhash is: '+BlockHash;
-                document.getElementById('Blockbutton').innerHTML='<button class="btn btn-raised btn-success btn-xs getBlockActionButton" data-hash="'+BlockHash+'">Get block</button>';
+                document.getElementById('block_output_table').innerHTML='<tr><td >'+'Blockhash is:</td><td  width="300px"> '+BlockHash+'</td></tr>';
+                $('#BlockExp_blockhash').val(BlockHash);
         
                 }
         });
@@ -83,16 +96,20 @@ var getBlockhash= function(height){
  * 
  */
 var getBlock= function(hash){
-    
+    var inputhash=$('#BlockExp_blockhash').val();
+    if(inputhash!==hash){
+        hash=inputhash;
+    }
     var request="{\"agent\":\"ramchain\",\"method\":\"getblock\",\"blockhash\":\""+hash+"\",\"remoteonly\":\""+checkExternalBlock+"\"}";
     
     SPNAPI.makeRequest(request, function(request,response){
             response=JSON.parse(response);
             if(response.result){
-                document.getElementById('Blockoutput').innerHTML=response.result;
+                document.getElementById('block_output_table').innerHTML='<tr><td >'+'Block is: </td><td >'+response.result+'</th></td>';
                 Block=response.result;
-                document.getElementById('transactionButton').innerHTML='<button class="btn btn-raised btn-success btn-xs getTrancationActionButton" data-hash="'+Block+'">Get transaction</button>';
-        
+                }else if(response.error){
+                document.getElementById('block_output_table').innerHTML='<tr><td >'+JSON.stringify(response)+'</th></td>';
+                    
                 }
         });
     
@@ -111,8 +128,12 @@ var getBlock= function(hash){
 //e7386986f14c994d6c70e8eb60753ea1fe2dc2a58567e6269dc6b04ef5310693
 //5f7edfb417855f80b7c12e1a9c040f8b496db23c82c90e4de905b8cff8139f03
 var getRawTransaction=function(Hash){
-    var request="{\"agent\":\"ramchain\",\"method\":\"getrawtransaction\",\"txid\":\"5f7edfb417855f80b7c12e1a9c040f8b496db23c82c90e4de905b8cff8139f03\",\"verbose\":1}";
+    
+    var inputhash=$('#BlockExp_txid').val();
+    var request="{\"agent\":\"ramchain\",\"method\":\"getrawtransaction\",\"txid\":\""+inputhash+"\",\"verbose\":1}";
     SPNAPI.makeRequest(request, function(request,response){
+        document.getElementById('block_output_table').innerHTML='<tr><td>'+'Output is:</td><td width="300px"> '+response+'</th></td>';
+                
             /*response=JSON.parse(response);
             if(response.result){
                 document.getElementById('Blockoutput').innerHTML=response.result;
@@ -120,6 +141,22 @@ var getRawTransaction=function(Hash){
         
                 }*/
         });
+};
+
+var change_ExternalBlocks=function(){
+    
+
+            if(document.getElementById('cbChangeExternalBlocks').checked){
+                    checkExternalBlock=1;
+            }else{
+                 checkExternalBlock=0;
+            }
+            console.log("CheckExternalBlock flag change to "+checkExternalBlock);
+    
+};
+
+document.getElementById('cbChangeExternalBlocks').onclick = function () {
+    change_ExternalBlocks();
 };
 
 /*
@@ -132,4 +169,12 @@ var startBlockExplorer=function(){
     setCoinRadio();
 
 };
-
+var blockExp_input_table=function(){
+  
+    var table='<tr><th>Input height:</th><td><input type="text" id="BlockExp_height"></td>\
+<td><button class="btn btn-raised btn-success btn-xs getBlockHashActionButton" data-height="0">Get blockhash</button></td></tr>\
+<tr><th>Blockhash:</th><td><input type="text" id="BlockExp_blockhash" value=""></td><td><button class="btn btn-raised btn-success btn-xs getBlockActionButton" data-hash="">Get block</button></td></tr>\n\
+<tr><th>Txid:</th><td><input type="text" id="BlockExp_txid"></td><td><button class="btn btn-raised btn-success btn-xs getTrancationActionButton" data-hash="">Get transaction</button></td></tr>';
+    document.getElementById('block_input_table').innerHTML=table;
+    document.getElementById('block_output_table').innerHTML="";
+};

--- a/iguana/manifest.json
+++ b/iguana/manifest.json
@@ -8,7 +8,7 @@
     "name": "Iguana",
     "version": "0.0.1",
     "icons": {
-        "128": "iguana/icon128.png"
+        "128": "icon128.png"
     },
     "minimum_chrome_version": "36",
     "sockets": {


### PR DESCRIPTION
I have changed according to feedback in block explorer.
I have also modified previous method for making GET API requests (in iguana/api.js) and added capability to check method and use GET or POST.
To test post requests you can try apikeypair and setuserid (given on instantdex tab) rest of the API calls will use GET requests only.(if we need to add others we can add them too )
Also i have Deleted settings tab. 
Not included image in blockexplorer for now
