### PR TITLE
Update scripts to automate libsecp256k1 dependency build and inclusion

### DIFF
--- a/iguana/m_unix
+++ b/iguana/m_unix
@@ -1,2 +1,2 @@
 git pull
-gcc  -o ../agents/iguana -O2 *.c ../agents/libcrypto777.a  -lcurl -lssl -lcrypto -lpthread -lm
+gcc  -o ../agents/iguana -O2 *.c ../agents/libcrypto777.a  -lcurl -lssl -lcrypto -lpthread -lm ../includes/libsecp256k1.a -lgmp

--- a/m_onetime
+++ b/m_onetime
@@ -1,3 +1,17 @@
+#!/bin/bash
+
+if  [ ! -f includes/secp256k1 ]; then
+echo Cloning and Building secp256k1 library...
+cd ..
+git clone https://github.com/ElementsProject/secp256k1-zkp.git
+cd secp256k1-zkp
+./autogen.sh
+./configure --enable-experimental --enable-module-ecdh --enable-module-schnorr --enable-module-rangeproof
+make
+cp .libs/libsecp256k1.a ../SuperNET/includes/
+cd ../SuperNET
+fi
+
 git pull
 cd crypto777
 ./$1


### PR DESCRIPTION
Modified SuperNET/m_onetime so it will fetch, build and copy secp256k1 static library to SuperNET/includes. 
Modified SuperNET/iguana/m_unix to include libsecp256k1.a in iguana binary build.
