### PR TITLE
Display GUI when accessed from a browser

### DIFF
--- a/iguana/iguana_rpc.c
+++ b/iguana/iguana_rpc.c
@@ -822,7 +822,7 @@ cJSON *SuperNET_urlconv(char *value,int32_t bufsize,char *urlstr)
 char *SuperNET_rpcparse(struct supernet_info *myinfo,char *retbuf,int32_t bufsize,int32_t *jsonflagp,int32_t *postflagp,char *urlstr,char *remoteaddr,char *filetype,uint16_t port)
 {
     cJSON *tokens,*argjson,*origargjson,*json = 0; long filesize;
-    char symbol[16],buf[4096],urlmethod[16],*data,url[1024],*retstr,*filestr,*token = 0; int32_t i,j,n,num=0;
+    char symbol[16],buf[4096],urlmethod[16],*data,url[1024],furl[1024],*retstr,*filestr,*token = 0; int32_t i,j,n,num=0;
     //printf("rpcparse.(%s)\n",urlstr);
     for (i=0; i<sizeof(urlmethod)-1&&urlstr[i]!=0&&urlstr[i]!=' '; i++)
         urlmethod[i] = urlstr[i];
@@ -837,6 +837,12 @@ char *SuperNET_rpcparse(struct supernet_info *myinfo,char *retbuf,int32_t bufsiz
     j = i = 0;
     filetype[0] = 0;
     //printf("url.(%s) method.(%s)\n",&url[i],urlmethod);
+    #ifdef __PNACL__
+    char *prefix="DB/";
+    snprintf(furl, sizeof furl, "%s%s", prefix,url+1);
+    #else
+    snprintf(furl, sizeof furl, "%s", url+1);
+    #endif
     if ( strcmp(&url[i],"/") == 0 && strcmp(urlmethod,"GET") == 0 )
     {
         static int counter;
@@ -852,7 +858,7 @@ char *SuperNET_rpcparse(struct supernet_info *myinfo,char *retbuf,int32_t bufsiz
             return(filestr);
         else return(clonestr("{\"error\":\"cant find index7778\"}"));
     }
-    else if ( (filestr= OS_filestr(&filesize,url+1)) != 0 )
+    else if ( (filestr= OS_filestr(&filesize,furl)) != 0 )
     {
         *jsonflagp = 1;
         for (i=(int32_t)strlen(url)-1; i>0; i--)

--- a/iguana/manifest.json
+++ b/iguana/manifest.json
@@ -16,6 +16,9 @@
     "128": "icon128.png"
   },
   "minimum_chrome_version": "36",
+  "web_accessible_resources":[
+      "help/*"
+  ],
   "permissions": [ 
       { "socket": [
         "tcp-listen:*:*",
@@ -26,7 +29,9 @@
       ]
     },
       "unlimitedStorage", 
-      {"fileSystem": ["write"]},
+      {"fileSystem": ["write",
+                "retainEntries", 
+                "directory"]},
       "storage",
       "system.storage",
       "system.display",


### PR DESCRIPTION
The GUI can now be accessed from a browser by pointing to the URL: 127.0.0.1:7778. This was broken due to two reasons:
1. The help files were not available in the HTML5 file-system (in this case DB/help)
2. iguana_rpc.c, tries to retrieve static files (example 127.0.0.1:7778/help/bootstrap.min.js) directly from the "help" directory. This would work when the application is run from a command line, the iguana executable and the "help" directory reside in the same location. When run as a PNaCL module, the HTML5 file-system is mounted at "DB", so the correct path should be "DB/help".

Issue 1 has been addressed by copying the contents of the "help" directory packaged in the Chrome app to the file system. Issue 2 has been addressed by using a "DB/" prefix when compiled as a PNaCL module.
