### PR TITLE
Ensure nacl fs is ready before copying files

### DIFF
--- a/iguana/example.js
+++ b/iguana/example.js
@@ -121,18 +121,13 @@ function domContentLoaded(name, tc, config, width, height) {
       window.requestFileSystem(PERSISTENT, bytes, function(fs) {
         console.log('Opened file system: ' + fs.name);
         fileSystem = fs;
-        copyHelpFiles().done(function() {
-          common.updateStatus(
+        common.updateStatus(
             'Allocated ' + bytes + ' bytes of persistent storage. Running the first time will take 17 seconds to load');
           common.attachDefaultListeners();
           common.createNaClModule(name, tc, config, width, height);
-        });
-        /*dirReader = fs.root.createReader();
-        dirReader.readEntries(function(results) {
-            console.log(results);
-          }, function(){
-            console.log('File IO error');
-          });*/
+        setTimeout(function(){
+          copyHelpFiles();
+        },2000);
       }, errorHandler);
     },
     function(e) {


### PR DESCRIPTION
There is a small latency between when the NaCL module is loaded and the HTML5 file system becomes available. As a result the help files are not copied, which prevents the index7778.html from being created.
