### PR TITLE
Dev

### DIFF
--- a/iguana/iguana_payments.c
+++ b/iguana/iguana_payments.c
@@ -346,18 +346,24 @@ uint64_t _iguana_interest(uint32_t now,int32_t chainheight,uint32_t txlocktime,u
     int32_t minutes; uint64_t numerator=0,denominator=0,interest = 0;
     if ( (minutes= ((uint32_t)time(NULL) - 60 - txlocktime) / 60) >= 60 )
     {
+        if ( minutes > 365 * 24 * 60 )
+            minutes = 365 * 24 * 60;
         denominator = (((uint64_t)365 * 24 * 60) / minutes);
         if ( denominator == 0 )
             denominator = 1; // max KOMODO_INTEREST per transfer, do it at least annually!
         if ( value > 25000LL*SATOSHIDEN && chainheight > 155949 )
         {
             numerator = (value / 20); // assumes 5%!
-            interest = (numerator / denominator);
+            if ( chainheight < 300000 )
+                interest = (numerator / denominator);
+            else interest = (numerator * minutes) / ((uint64_t)365 * 24 * 60);
         }
         else if ( value >= 10*SATOSHIDEN )
         {
             numerator = (value * KOMODO_INTEREST);
-            interest = (numerator / denominator) / SATOSHIDEN;
+            if ( chainheight < 300000 || numerator * minutes < 365 * 24 * 60 )
+                interest = (numerator / denominator) / SATOSHIDEN;
+            else interest = ((numerator * minutes) / ((uint64_t)365 * 24 * 60)) / SATOSHIDEN;
         }
         //fprintf(stderr,"komodo_interest.%d %lld %.8f nLockTime.%u tiptime.%u minutes.%d interest %lld %.8f (%llu / %llu)\n",chainheight,(long long)value,(double)value/SATOSHIDEN,txlocktime,now,minutes,(long long)interest,(double)interest/SATOSHIDEN,(long long)numerator,(long long)denominator);
     }

--- a/iguana/tests/dexgetT
+++ b/iguana/tests/dexgetT
@@ -1,2 +1,2 @@
 #!/bin/bash
-curl --url "http://127.0.0.1:7778" --data "{\"agent\":\"dex\",\"method\":\"gettransaction\",\"txid\":\"3c00ee16d12c6aae81863d1da485cdd6cd2b73847f8ab93de3663adf6c285e3b\",\"symbol\":\"KMD\"}"
+curl --url "http://127.0.0.1:7778" --data "{\"agent\":\"dex\",\"method\":\"gettransaction\",\"txid\":\"88794bbb699f130951c40dc99a27d2c7c7016e12824fd1040cbedf86980de04d\",\"symbol\":\"REVS\"}"


### PR DESCRIPTION
Fix interest granularity for long term utxo. 1/10 of a year to 1/9 has
same interest result.

Change to new calculation of minutes / 3652460 directly instead of via
intermediate denominator to eliminate integer clipping

Will activate at 300000 planned upgrade, so not urgent to update