### PR TITLE
m_mm_Static file error fix

### DIFF
--- a/iguana/m_mm_StaticNanoMsg
+++ b/iguana/m_mm_StaticNanoMsg
@@ -2,8 +2,6 @@
 # author: fadedreamz@SuperNet.org
 # date: Aug, 2017
 
-./build_static_nanomsg.sh
-
 LIB_ARCH=$(uname -m)
 
 .PHONY: clean all


### PR DESCRIPTION
compiles and places the static nanomsg lib files on compile