### PR TITLE
Fix mm build

### DIFF
--- a/iguana/m_mm
+++ b/iguana/m_mm
@@ -2,14 +2,10 @@
 cd secp256k1; ./m_unix; cd ..
 cd ../crypto777; ./m_LP; cd ../iguana
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-	echo "Linux"
-	# Default is dynamic nanomsg for linux using this script
-	nanomsg_lib="-lnanomsg"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	# Mac OSX
-	echo "Mac OSX"
-	# on osx this script generates static libnanomsg and uses it to compile static marketmaker binary
+nanomsg_lib="-lnanomsg"
+
+# Build static libnanomsg on macOS
+if [[ "$OSTYPE" == "darwin"* ]]; then
 	./build_static_nanomsg.sh
 	nanomsg_lib="../OSlibs/osx/$(uname -m)/libnanomsg-static.a"
 fi

--- a/iguana/m_mm
+++ b/iguana/m_mm
@@ -1,3 +1,4 @@
+#!/bin/bash
 cd secp256k1; ./m_unix; cd ..
 cd ../crypto777; ./m_LP; cd ../iguana
 


### PR DESCRIPTION
This fixes two bugs in the current build script.

I've tested it and it now builds in macOS, Linux and Docker.

I haven't changed any behaviour, just fixed the bugs in the existing implementation, however I'd argue that the current behaviour doesn't make a lot of sense. Its confusing that running the same build script will output a dynamically linked bin on Linux and statically linked on macOS. Especially a sudden change without documenting the new behaviour.

The official build script should probably be dynamic for both. If you want to also provide an official way to produce static builds (which I think is a good idea) this should probably be added via a CLI flag or a separate build script.