### PR TITLE
Fix missing early return bug in LP_cancel_order

### DIFF
--- a/iguana/exchanges/LP_ordermatch.c
+++ b/iguana/exchanges/LP_ordermatch.c
@@ -629,7 +629,7 @@ char *LP_cancel_order(char *uuidstr)
     {
         LP_failedmsg(LP_Alicequery.R.requestid,LP_Alicequery.R.quoteid,-9998,LP_Alicequery.uuidstr);
         LP_alicequery_clear();
-        clonestr("{\"result\":\"success\",\"status\":\"uuid canceled\"}");
+        return(clonestr("{\"result\":\"success\",\"status\":\"uuid canceled\"}"));
     }
     return(clonestr("{\"error\":\"uuid not cancellable\"}"));
 }


### PR DESCRIPTION
Without this change, `LP_cancel_order` always returns an error, even if the command is successful.