### PR TITLE
Update acsplit to use 10,000 sats

### DIFF
--- a/iguana/acsplit
+++ b/iguana/acsplit
@@ -1,1 +1,1 @@
-curl --url "http://127.0.0.1:7776" --data "{\"coin\":\""${1}"\",\"agent\":\"iguana\",\"method\":\"splitfunds\",\"satoshis\":\"50000\",\"sendflag\":1,\"duplicates\":"${2}"}"
+curl --url "http://127.0.0.1:7776" --data "{\"coin\":\""${1}"\",\"agent\":\"iguana\",\"method\":\"splitfunds\",\"satoshis\":\"10000\",\"sendflag\":1,\"duplicates\":"${2}"}"


### PR DESCRIPTION
https://komodo-platform.slack.com/archives/C2J9Z9KRP/p1525159679000123

```
jorian [2:27 PM]
also make sure acsplit is 10000 sats instead of 50000 (has that been fixed?)

Dwy [2:28 PM]
Acsplit will do it on its own :)

lukechilds [2:28 PM]
oh you mean I send my mining rewards back to myself>

pondsea [2:28 PM]
Yeah that is the easiest way to get a sendtoaddress utxo

lukechilds [2:30 PM]
>also make sure acsplit is 10000 sats instead of 50000 (has that been fixed?)
looks like 50000 to me:
```curl --url "http://127.0.0.1:7776" --data "{\"coin\":\""${1}"\",\"agent\":\"iguana\",\"method\":\"splitfunds\",\"satoshis\":\"50000\",\"sendflag\":1,\"duplicates\":"${2}"}"```
should I submit a PR to change to 10000?
@Dwy
>Acsplit will do it on its own :slightly_smiling_face:
It will automatically send my mining rewards to myself? So I don’t need to do it manually (edited)

pondsea [2:31 PM]
No it wont
You have to do it in the first place since you have no sendtoaddress types of UTXOs

Dwy [2:32 PM]
No. It will split the amount you want for the asset you want

lukechilds [2:32 PM]
ok cool, and re PR, acsplit should be 10,000 right?

Dwy [2:32 PM]
Like ./acsplit KMD 100 will create 100 utxo sized for iguana


jorian [2:32 PM]
yes

Dwy [2:33 PM]
Yeah. If not you can just edit it
```