### PR TITLE
Allow passing custom args to iguana

### DIFF
--- a/iguana/m_notary_run
+++ b/iguana/m_notary_run
@@ -8,7 +8,8 @@ clang -g -Wno-deprecated -c -O2 -DISNOTARYNODE=1 -DLIQUIDITY_PROVIDER=1 *.c ../b
 clang -g  -Wno-deprecated -c -DISNOTARYNODE=1 -DLIQUIDITY_PROVIDER=1  main.c iguana777.c iguana_bundles.c ../basilisk/basilisk.c
 clang -g -o ../agents/iguana *.o ../agents/libcrypto777.a -lnanomsg -lcurl -lssl -lcrypto -lpthread -lz -lm
 
-stdbuf -oL $1 ../agents/iguana notary  & #> iguana.log 2> error.log  &
+iguana_arg=${2:-notary}
+stdbuf -oL $1 ../agents/iguana $iguana_arg  & #> iguana.log 2> error.log  &
 
 myip=`curl -s4 checkip.amazonaws.com`
 source pubkey.txt


### PR DESCRIPTION
This allows people to pass custom arguments to `iguana` without having to fork and maintain their own repo and keep it up to date with upstream.

This is a backwards compatible change, default behaviour is identical.

```shell
# ./m_notary will result in the same iguana command as before this PR:
$ ./m_notary
# results in:
stdbuf -oL ../agents/iguana notary

# However you can now change the `notary` option to whatever you want:
$ ./m_notary "" notary_nosplit
# results in:
stdbuf -oL ../agents/iguana notary_nosplit
```

---

This is just a short term fix. I think in the long run we should split the `./m_notary` functionality out into multiple scripts with a single purpose.

I don't think it makes sense to have a single script that:
- kills the currently running daemon
- checks out a hardcoded branch
- git pulls
- builds
- launches the daemon
- sends it a load of setup requests

Those are all separate tasks and they shouldn't be combined.