### PR TITLE
Make sure second arg gets passed from m_notary to m_notary_run

### DIFF
--- a/iguana/m_notary
+++ b/iguana/m_notary
@@ -2,4 +2,4 @@
 pkill -15 iguana
 rm -f ../agents/iguana *.o
 git pull
-./m_notary_run $1
+./m_notary_run $1 $2


### PR DESCRIPTION
Following on from https://github.com/jl777/SuperNET/pull/932

I was just testing locally with `./m_notary_run` and forgot to pass `$2` through from `./m_notary`.

🤦‍♂️ 