### PR TITLE
Quote `m_notary_run` args

### DIFF
--- a/iguana/m_notary
+++ b/iguana/m_notary
@@ -2,4 +2,4 @@
 pkill -15 iguana
 rm -f ../agents/iguana *.o
 git pull
-./m_notary_run $1 $2
+./m_notary_run "$1" "$2"


### PR DESCRIPTION
The args need to be quoted to allow passing an empty `$1` in as `""`. Otherwise `$2` will be interpreted as `$1` and passed to `stdbuf` instead of `iguana`.