### PR TITLE
+ zex_7776 start in m_notary_run

### DIFF
--- a/iguana/m_notary_run
+++ b/iguana/m_notary_run
@@ -103,6 +103,7 @@ coins/mgnx_7776
 coins/pgt_7776
 coins/kmdice_7776
 coins/dion_7776
+coins/zex_7776
 
 #curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"passthru\",\"method\":\"paxfiats\",\"timeout\":900000}"
 


### PR DESCRIPTION
added zex_7776  start m_notary_run ... commit name contains mistake, but commit content is correct.