### PR TITLE
Add lukechilds node IPs to m_notary_KMD

### DIFF
--- a/iguana/m_notary_KMD
+++ b/iguana/m_notary_KMD
@@ -14,6 +14,14 @@ curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"SuperNET\",\"method\":\"
 sleep 3
 
 # TODO: Need to get some seeds for both networks. 
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"178.128.93.117\"}"   # lukechilds AR primary static IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"157.230.47.150\"}"   # lukechilds AR secondary static IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"67.207.94.69\"}"     # lukechilds NA primary static IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"167.71.178.51\"}"    # lukechilds NA secondary static IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"159.89.210.91\"}"    # lukechilds AR primary floating IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"139.59.218.49\"}"    # lukechilds AR secondary floating IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"165.227.253.204\"}"  # lukechilds NA primary floating IP
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"138.197.62.182\"}"   # lukechilds NA secondary floating IP
 curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"103.6.12.105\"}"
 
 # This will add all KMD assetchains from assetchains.json.


### PR DESCRIPTION
I've added the IPs for my AR and NA nodes, both the primary and secondary servers.

I've added the static IPs of the actual nodes, and also floating IPs that point to the static IPs. If I ever change IP address for any reason, the static IPs will fail but the floating IPs will still forward to the new nodes, so I'll still be able to improve connectivity to the network without people updating.

Let me know if this is ok or if you only want primary node IPs in `m_notary_KMD`.