### PR TITLE
Take coin->active into account

### DIFF
--- a/iguana/dpow/dpow_rpc.c
+++ b/iguana/dpow/dpow_rpc.c
@@ -60,6 +60,7 @@ char *bitcoind_getinfo(char *symbol,char *serverport,char *userpass,char *getinf
 cJSON *dpow_getinfo(struct supernet_info *myinfo,struct iguana_info *coin)
 {
     char buf[128],*retstr=0; cJSON *json = 0;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         buf[0] = 0;
@@ -95,6 +96,7 @@ cJSON *dpow_getinfo(struct supernet_info *myinfo,struct iguana_info *coin)
 uint32_t dpow_CCid(struct supernet_info *myinfo,struct iguana_info *coin)
 {
     uint32_t CCid = 0; cJSON *retjson;
+    if ( coin->active == 0 ) return (CCid);
     if ( (retjson= dpow_getinfo(myinfo,coin)) != 0 )
     {
         CCid = juint(retjson,"CCid");
@@ -223,6 +225,7 @@ int32_t komodo_notaries(char *symbol,uint8_t pubkeys[64][33],int32_t height)
 bits256 dpow_getbestblockhash(struct supernet_info *myinfo,struct iguana_info *coin)
 {
     char *retstr; bits256 blockhash;
+    if ( coin->active == 0 ) return (blockhash);
     memset(blockhash.bytes,0,sizeof(blockhash));
     if ( coin->FULLNODE < 0 )
     {
@@ -256,6 +259,7 @@ bits256 dpow_getbestblockhash(struct supernet_info *myinfo,struct iguana_info *c
 cJSON *issue_calcMoM(struct iguana_info *coin,int32_t height,int32_t MoMdepth)
 {
     char buf[128],*retstr=0; cJSON *retjson = 0;
+    if ( coin->active == 0 ) return (retjson);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"[\"%d\", \"%d\"]",height,MoMdepth);
@@ -272,6 +276,7 @@ cJSON *issue_calcMoM(struct iguana_info *coin,int32_t height,int32_t MoMdepth)
 cJSON *dpow_MoMoMdata(struct iguana_info *coin,char *symbol,int32_t kmdheight,uint16_t CCid)
 {
     char buf[128],*retstr=0; cJSON *retjson = 0; struct iguana_info *src;
+    if ( coin->active == 0 ) return (retjson);
     if ( coin->FULLNODE < 0 && strcmp(coin->symbol,"KMD") == 0 && (src= iguana_coinfind(symbol)) != 0 )
     {
         sprintf(buf,"[\"%s\", \"%d\", \"%d\"]",symbol,kmdheight,CCid);
@@ -376,6 +381,7 @@ bits256 dpow_getblockhash(struct supernet_info *myinfo,struct iguana_info *coin,
 {
     char buf[128],*retstr=0; bits256 blockhash;
     memset(blockhash.bytes,0,sizeof(blockhash));
+    if ( coin->active == 0 ) return blockhash;
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"%d",height);
@@ -404,6 +410,7 @@ bits256 dpow_getblockhash(struct supernet_info *myinfo,struct iguana_info *coin,
 cJSON *dpow_getblock(struct supernet_info *myinfo,struct iguana_info *coin,bits256 blockhash)
 {
     char buf[128],str[65],*retstr=0; cJSON *json = 0;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"\"%s\"",bits256_str(str,blockhash));
@@ -431,6 +438,7 @@ cJSON *dpow_getblock(struct supernet_info *myinfo,struct iguana_info *coin,bits2
 char *dpow_validateaddress(struct supernet_info *myinfo,struct iguana_info *coin,char *address)
 {
     char buf[128],*retstr=0; cJSON *retjson;
+    if ( coin->active == 0 ) return (retstr);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"\"%s\"",address);
@@ -465,6 +473,7 @@ char *dpow_validateaddress(struct supernet_info *myinfo,struct iguana_info *coin
 cJSON *dpow_gettxout(struct supernet_info *myinfo,struct iguana_info *coin,bits256 txid,int32_t vout)
 {
     char buf[128],str[65],*retstr=0; cJSON *json = 0;
+    if ( coin->active == 0 ) return (json);
     sprintf(buf,"\"%s\", %d",bits256_str(str,txid),vout);
     if ( coin->FULLNODE < 0 )
     {
@@ -492,6 +501,7 @@ cJSON *dpow_gettxout(struct supernet_info *myinfo,struct iguana_info *coin,bits2
 int dpow_lockunspent(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr,char *txid,int32_t vout)
 {
     char buf[128],*retstr;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"false, [{\"txid\":\"%s\",\"vout\":%d}]", txid, vout);
@@ -508,6 +518,7 @@ int dpow_lockunspent(struct supernet_info *myinfo,struct iguana_info *coin,char 
 int dpow_unlockunspent(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr,char *txid,int32_t vout)
 {
     char buf[128],*retstr;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"true, [{\"txid\":\"%s\",\"vout\":%d}]", txid, vout);
@@ -524,6 +535,7 @@ int dpow_unlockunspent(struct supernet_info *myinfo,struct iguana_info *coin,cha
 char *dpow_decoderawtransaction(struct supernet_info *myinfo,struct iguana_info *coin,char *rawtx)
 {
     char *retstr,*paramstr; cJSON *array;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         array = cJSON_CreateArray();
@@ -548,6 +560,7 @@ char *dpow_decoderawtransaction(struct supernet_info *myinfo,struct iguana_info 
 int32_t dpow_txconfirms(struct supernet_info *myinfo,struct iguana_info *coin,bits256 txid, char *rawtx)
 {
     cJSON *txobj; int32_t confirms = 0, ret = 0;
+    if ( coin->active == 0 ) return (ret);
     if ( (txobj= dpow_gettransaction(myinfo, coin, txid)) != 0 )
     {
         memcpy(rawtx, jstr(txobj, "hex"), strlen(jstr(txobj, "hex"))+1);
@@ -565,6 +578,7 @@ int32_t dpow_txconfirms(struct supernet_info *myinfo,struct iguana_info *coin,bi
 cJSON *dpow_gettransaction(struct supernet_info *myinfo,struct iguana_info *coin,bits256 txid)
 {
     char buf[128],str[65],*retstr=0; cJSON *json = 0;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"[\"%s\", 1]",bits256_str(str,txid));
@@ -592,6 +606,7 @@ cJSON *dpow_gettransaction(struct supernet_info *myinfo,struct iguana_info *coin
 cJSON *dpow_listunspent(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr)
 {
     char buf[128],*retstr; cJSON *array,*json = 0;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(buf,"1, 99999999, [\"%s\"]",coinaddr);
@@ -618,6 +633,7 @@ cJSON *dpow_listunspent(struct supernet_info *myinfo,struct iguana_info *coin,ch
 
 cJSON *dpow_listspent(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr)
 {
+    if ( coin->active == 0 ) return (0);
     if ( myinfo->DEXEXPLORER != 0 )
         return(kmd_listspent(myinfo,coin,coinaddr));
     else
@@ -628,6 +644,7 @@ cJSON *dpow_listspent(struct supernet_info *myinfo,struct iguana_info *coin,char
 
 cJSON *dpow_getbalance(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr)
 {
+    if ( coin->active == 0 ) return (0);
     if ( myinfo->DEXEXPLORER != 0 )
         return(kmd_getbalance(myinfo,coin,coinaddr));
     else
@@ -638,6 +655,7 @@ cJSON *dpow_getbalance(struct supernet_info *myinfo,struct iguana_info *coin,cha
 
 cJSON *dpow_gettxin(struct supernet_info *myinfo,struct iguana_info *coin,bits256 txid,int32_t vout)
 {
+    if ( coin->active == 0 ) return (0);
     if ( myinfo->DEXEXPLORER != 0 )
         return(kmd_gettxin(coin,txid,vout));
     else
@@ -649,6 +667,7 @@ cJSON *dpow_gettxin(struct supernet_info *myinfo,struct iguana_info *coin,bits25
 cJSON *dpow_listtransactions(struct supernet_info *myinfo,struct iguana_info *coin,char *coinaddr,int32_t count,int32_t skip)
 {
     char buf[128],*retstr; cJSON *json = 0;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         if ( count == 0 )
@@ -668,6 +687,7 @@ cJSON *dpow_listtransactions(struct supernet_info *myinfo,struct iguana_info *co
 char *dpow_signrawtransaction(struct supernet_info *myinfo,struct iguana_info *coin,char *rawtx,cJSON *vins)
 {
     cJSON *array,*privkeys,*item,*retjson; char *wifstr,*str,*paramstr,*retstr; uint8_t script[256]; int32_t i,n,len,hashtype; struct vin_info V; struct iguana_waddress *waddr; struct iguana_waccount *wacct;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         array = cJSON_CreateArray();
@@ -740,6 +760,7 @@ char *dpow_signrawtransaction(struct supernet_info *myinfo,struct iguana_info *c
 cJSON *dpow_kvupdate(struct supernet_info *myinfo,struct iguana_info *coin,char *key,char *value,int32_t flags)
 {
     char params[IGUANA_MAXSCRIPTSIZE+256],*retstr; cJSON *retjson;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(params,"[\"%s\", \"%s\", \"%d\"]",key,value,flags);
@@ -758,6 +779,7 @@ cJSON *dpow_kvupdate(struct supernet_info *myinfo,struct iguana_info *coin,char 
 cJSON *dpow_kvsearch(struct supernet_info *myinfo,struct iguana_info *coin,char *key)
 {
     char params[IGUANA_MAXSCRIPTSIZE+256],*retstr; cJSON *retjson;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         sprintf(params,"[\"%s\"]",key);
@@ -776,6 +798,7 @@ cJSON *dpow_kvsearch(struct supernet_info *myinfo,struct iguana_info *coin,char 
 char *dpow_sendrawtransaction(struct supernet_info *myinfo,struct iguana_info *coin,char *signedtx)
 {
     bits256 txid; cJSON *json,*array; char *paramstr,*retstr;
+    if ( coin->active == 0 ) return (0);
     if ( coin->FULLNODE < 0 )
     {
         array = cJSON_CreateArray();
@@ -802,6 +825,7 @@ char *dpow_sendrawtransaction(struct supernet_info *myinfo,struct iguana_info *c
 char *dpow_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin)
 {
     char *retstr,fname[1024]; long filesize;
+    if ( coin->active == 0 ) return (0);
     sprintf(fname,"%s/alladdresses.%s",GLOBAL_CONFSDIR,coin->symbol), OS_compatible_path(fname);
     retstr = OS_filestr(&filesize,fname);
     return(retstr);
@@ -810,6 +834,7 @@ char *dpow_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin)
 void update_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin,char *address)
 {
     struct hashstr_item *hashstr,*tmp; cJSON *alljson; char *outstr,*instr,fname[1024]; int32_t i,n,saveflag = 0;
+    if ( coin->active == 0 ) return;
     HASH_FIND(hh,coin->alladdresses,address,strlen(address),hashstr);
     if ( hashstr == 0 )
     {
@@ -861,6 +886,7 @@ void update_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin,c
 cJSON *dpow_checkaddress(struct supernet_info *myinfo,struct iguana_info *coin,char *address)
 {
     int32_t isvalid=0,doneflag=0; char *retstr; cJSON *validatejson,*retjson = cJSON_CreateObject();
+    if ( coin->active == 0 ) return (retjson);
     if ( (retstr= dpow_validateaddress(myinfo,coin,address)) != 0 )
     {
         if ( (validatejson= cJSON_Parse(retstr)) != 0 )
@@ -888,6 +914,7 @@ cJSON *dpow_checkaddress(struct supernet_info *myinfo,struct iguana_info *coin,c
 char *dpow_importaddress(struct supernet_info *myinfo,struct iguana_info *coin,char *address)
 {
     char buf[1024],*retstr; cJSON *validatejson; int32_t isvalid=0,doneflag = 0;
+    if ( coin->active == 0 ) return "";
     if ( (retstr= dpow_validateaddress(myinfo,coin,address)) != 0 )
     {
         if ( (validatejson= cJSON_Parse(retstr)) != 0 )
@@ -920,6 +947,7 @@ char *dpow_importaddress(struct supernet_info *myinfo,struct iguana_info *coin,c
 void init_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin)
 {
     char *alladdresses,*retstr; cJSON *alljson; int32_t i,n;
+    if ( coin->active == 0 ) return;
     if ( (alladdresses= dpow_alladdresses(myinfo,coin)) != 0 )
     {
         printf("(%s) ALL.(%s)\n",coin->symbol,alladdresses);
@@ -940,6 +968,7 @@ void init_alladdresses(struct supernet_info *myinfo,struct iguana_info *coin)
 int32_t dpow_getchaintip(struct supernet_info *myinfo,bits256 *merklerootp,bits256 *blockhashp,uint32_t *blocktimep,bits256 *txs,uint32_t *numtxp,struct iguana_info *coin)
 {
     int32_t n,i,height = -1,maxtx = *numtxp; bits256 besthash,oldhash; cJSON *array,*json;
+    if ( coin->active == 0 ) return (0);
     *numtxp = *blocktimep = 0;
     oldhash = coin->lastbesthash;
     *blockhashp = besthash = dpow_getbestblockhash(myinfo,coin);
@@ -989,6 +1018,7 @@ int32_t dpow_vini_ismine(struct supernet_info *myinfo,struct dpow_info *dp,cJSON
 int32_t dpow_haveutxo(struct supernet_info *myinfo,struct iguana_info *coin,bits256 *txidp,int32_t *voutp,char *coinaddr,char *srccoin)
 {
     int32_t vout,haveutxo = 0; uint32_t i,j,n,r; bits256 txid; cJSON *unspents,*item; uint64_t satoshis; char *str,*address; uint8_t script[35];
+    if ( coin->active == 0 ) return (0);
     memset(txidp,0,sizeof(*txidp));
     *voutp = -1;
     if ( (unspents= dpow_listunspent(myinfo,coin,coinaddr)) != 0 )


### PR DESCRIPTION
Now, I think that the iguana calls stopcoin and startcoin works without creating curl errors into iguanaTV.

Before this change, if we call stopcoin on iguana then we stop chips daemon, these errors occurred in iguanaTV:

curl_easy_perform() failed: Couldn't connect to server CHIPS.(127.0.0.1:***** getbestblockhash), retries: 4

curl_easy_perform() failed: Couldn't connect to server CHIPS.(127.0.0.1:***** getbestblockhash), retries: 4_